### PR TITLE
Use bootstrap classes to style tables by default

### DIFF
--- a/docutils_glep/html_writer/__init__.py
+++ b/docutils_glep/html_writer/__init__.py
@@ -38,4 +38,5 @@ class Writer(pep_html.Writer):
         'generator': '1',
         'datestamp': '%Y-%m-%d %H:%M UTC',
         'source_link': '1',
+        'table_style': 'table table-bordered',
         }

--- a/docutils_glep/html_writer/glep.css
+++ b/docutils_glep/html_writer/glep.css
@@ -80,6 +80,15 @@ THE SOFTWARE.
 	border-color: #ebccd1;
 }
 
+.table {
+	width: auto;
+}
+
+table.table > tbody > tr > td,
+table.table > tbody > tr > th {
+	vertical-align: middle;
+}
+
 /*
 the following bits are copied from:
 


### PR DESCRIPTION
Signed-off-by: Michał Górny <mgorny@gentoo.org>