### PR TITLE
glep.css: Use same font in Contents heading as in h2

### DIFF
--- a/docutils_glep/__init__.py
+++ b/docutils_glep/__init__.py
@@ -4,4 +4,4 @@ from docutils_glep.reader import Reader
 from docutils_glep.html_writer import Writer
 
 
-__version__ = "1.4"
+__version__ = "1.5"

--- a/docutils_glep/html_writer/__init__.py
+++ b/docutils_glep/html_writer/__init__.py
@@ -38,4 +38,5 @@ class Writer(pep_html.Writer):
         'generator': '1',
         'datestamp': '%Y-%m-%d %H:%M UTC',
         'source_link': '1',
+        'table_style': 'table table-bordered',
         }

--- a/docutils_glep/html_writer/glep.css
+++ b/docutils_glep/html_writer/glep.css
@@ -1,4 +1,7 @@
 .document .contents .topic-title {
+	/* same font family and weight as in h2 heading */
+	font-family: Bitter, 'Open Sans', sans-serif;
+	font-weight: 400;
 	font-size: 25px;
 }
 

--- a/docutils_glep/html_writer/glep.css
+++ b/docutils_glep/html_writer/glep.css
@@ -80,6 +80,15 @@ THE SOFTWARE.
 	border-color: #ebccd1;
 }
 
+.table {
+	width: auto;
+}
+
+table.table > tbody > tr > td,
+table.table > tbody > tr > th {
+	vertical-align: middle;
+}
+
 /*
 the following bits are copied from:
 


### PR DESCRIPTION
Update to match www.gentoo.org.